### PR TITLE
Add clip field and test validation

### DIFF
--- a/metadata/test1.json
+++ b/metadata/test1.json
@@ -1,8 +1,13 @@
 {
     "download_path": "/media/fritz/E4B0-3FC21/2025-05-13",
     "url": "https://www.facebook.com/share/v/19G7Jx2x2n/?mibextid=wwXIfr&__cft__[0]=AZWRlnH4PI4SsDap9XmHIiJ2UNb09CUq_fiXDnUeamxAKHTixL3j91_Rf4Q1qmRBQ2tqftspACfuRXaAJjLiaKAjHoywF6iNy5fZLyCy2VBBFxu7nrn3vmenyzjG8SezVAfyBhx7-AKXqXNqJ87LE4nM&__tn__=R]-R",
+    "clips": [
+        { "start": 3, "end": 10, "text": "First clip" },
+        { "start": 11, "end": 20, "text": "Second clip" }
+    ],
     "tasks": {
         "perform_download": null,
-        "apply_watermark": null
+        "apply_watermark": null,
+        "make_clips": true
     }
 }

--- a/t/22.metadata_tasks.t
+++ b/t/22.metadata_tasks.t
@@ -41,5 +41,11 @@ foreach my $file (@json_files) {
             unless defined $data->{tasks}{apply_watermark} && length $data->{tasks}{apply_watermark};
         pass("$file has apply_watermark");
     }
+
+    SKIP: {
+        skip "$file: make_clips missing", 1
+            unless defined $data->{tasks}{make_clips} && length $data->{tasks}{make_clips};
+        pass("$file has make_clips");
+    }
 }
 


### PR DESCRIPTION
## Summary
- add sample clip definitions in `test1.json`
- validate `make_clips` presence in metadata tests

## Testing
- `prove -l t/22.metadata_tasks.t`

------
https://chatgpt.com/codex/tasks/task_e_6854f7f2d638832bbb8a9ed4429d199a