### PR TITLE
Add screenshot timeline utilities

### DIFF
--- a/bin/convert_screenshots.py
+++ b/bin/convert_screenshots.py
@@ -1,0 +1,35 @@
+#!/usr/bin/env python
+"""Convert screenshot timestamps from MST to UTC and create a timeline."""
+import sys
+import os
+
+# Ensure library path is available
+current_dir = os.path.dirname(os.path.abspath(__file__))
+root_dir = os.path.dirname(current_dir)
+lib_path = os.path.join(root_dir, "lib")
+sys.path.append(lib_path)
+
+from python_utils import screenshot_utils as su
+
+
+def main(mst_json: str, output_dir: str = "metadata") -> None:
+    screens = su.load_screenshots(mst_json)
+    screens = su.convert_screenshots_to_utc(screens)
+    utc_path = os.path.join(output_dir, "screenshot_times_utc.json")
+    su.save_screenshots(screens, utc_path)
+
+    timeline = su.build_timeline(screens)
+    timeline_path = os.path.join(output_dir, "screenshot_timeline.json")
+    with open(timeline_path, "w", encoding="utf-8") as f:
+        import json
+        json.dump(timeline, f, indent=2)
+
+    print(utc_path)
+    print(timeline_path)
+
+
+if __name__ == "__main__":
+    if len(sys.argv) < 2:
+        print("Usage: convert_screenshots.py <mst_json> [output_dir]")
+        sys.exit(1)
+    main(sys.argv[1], sys.argv[2] if len(sys.argv) > 2 else "metadata")

--- a/lib/python_utils/screenshot_utils.py
+++ b/lib/python_utils/screenshot_utils.py
@@ -1,0 +1,41 @@
+import json
+from datetime import datetime, timedelta, timezone
+from typing import List, Dict
+
+MST_OFFSET_HOURS = -7  # Idaho Mountain Standard Time offset from UTC
+
+def load_screenshots(path: str) -> List[Dict]:
+    """Load screenshot metadata from JSON."""
+    with open(path, "r", encoding="utf-8") as f:
+        return json.load(f)
+
+
+def mst_to_utc(timestamp: str) -> str:
+    """Convert 'YYYY-MM-DD HH:MM:SS' MST time to UTC ISO 8601."""
+    local = datetime.strptime(timestamp, "%Y-%m-%d %H:%M:%S")
+    local = local.replace(tzinfo=timezone(timedelta(hours=MST_OFFSET_HOURS)))
+    return local.astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def convert_screenshots_to_utc(screens: List[Dict]) -> List[Dict]:
+    """Return screenshots with added 'timestamp_utc' entries."""
+    for entry in screens:
+        ts = entry.get("timestamp")
+        if ts:
+            entry["timestamp_utc"] = mst_to_utc(ts)
+    return screens
+
+
+def save_screenshots(data: List[Dict], path: str) -> None:
+    """Save screenshot metadata to JSON."""
+    with open(path, "w", encoding="utf-8") as f:
+        json.dump(data, f, indent=2)
+
+
+def build_timeline(screens: List[Dict], width: int = 1200, height: int = 800) -> Dict:
+    """Create a simple timeline JSON structure from ordered screenshots."""
+    events = [
+        {"label": s.get("filename"), "timestamp": s.get("timestamp_utc", s.get("timestamp"))}
+        for s in screens
+    ]
+    return {"canvas": {"width": width, "height": height}, "events": events}

--- a/metadata/screenshot_timeline.json
+++ b/metadata/screenshot_timeline.json
@@ -1,0 +1,22 @@
+{
+  "canvas": {
+    "width": 1200,
+    "height": 800
+  },
+  "events": [
+    {
+      "label": "frame001.png",
+      "timestamp": "2025-06-23T16:15:00Z"
+    },
+    {
+      "label": "frame002.png",
+      "timestamp": "2025-06-23T16:30:00Z"
+    },
+    {
+      "label": "frame003.png",
+      "timestamp": "2025-06-23T17:00:00Z"
+    }
+  ]
+}
+
+

--- a/metadata/screenshot_times_mst.json
+++ b/metadata/screenshot_times_mst.json
@@ -1,0 +1,5 @@
+[
+  {"filename": "frame001.png", "timestamp": "2025-06-23 09:15:00"},
+  {"filename": "frame002.png", "timestamp": "2025-06-23 09:30:00"},
+  {"filename": "frame003.png", "timestamp": "2025-06-23 10:00:00"}
+]

--- a/metadata/screenshot_times_utc.json
+++ b/metadata/screenshot_times_utc.json
@@ -1,0 +1,17 @@
+[
+  {
+    "filename": "frame001.png",
+    "timestamp": "2025-06-23 09:15:00",
+    "timestamp_utc": "2025-06-23T16:15:00Z"
+  },
+  {
+    "filename": "frame002.png",
+    "timestamp": "2025-06-23 09:30:00",
+    "timestamp_utc": "2025-06-23T16:30:00Z"
+  },
+  {
+    "filename": "frame003.png",
+    "timestamp": "2025-06-23 10:00:00",
+    "timestamp_utc": "2025-06-23T17:00:00Z"
+  }
+]


### PR DESCRIPTION
## Summary
- provide helpers to convert screenshot timestamps to UTC
- include CLI `convert_screenshots.py`
- add sample screenshot metadata and generated timeline

## Testing
- `prove -lv t` *(fails: IPC::System::Simple missing)*

------
https://chatgpt.com/codex/tasks/task_e_6859f10fc6e8832b91806086486edfef