### PR TITLE
Add missing executables to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,6 +12,14 @@ setup(
     scripts=[
         'bin/call_captions.py',
         'bin/call_clips.py',
-        'bin/call_watermark.py'
+        'bin/call_download.py',
+        'bin/call_router.py',
+        'bin/call_untar_and_sort.py',
+        'bin/call_watermark.py',
+        'bin/composite_timeline.py',
+        'bin/convert_screenshots.py',
+        'bin/dispatch.py',
+        'bin/download_images.py',
+        'bin/untar_and_list.py'
     ],
 )


### PR DESCRIPTION
## Summary
- include all runnable scripts in `setup.py` so they're installed via `setup()`

## Testing
- `git status --short`


------
https://chatgpt.com/codex/tasks/task_e_6859fe8b86b8832b8197e75b48d1e26a